### PR TITLE
Add new build script & add publicKey generate function

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,2 @@
-
 build
+output

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,6 @@
 [submodule "libsignal-protocol-c"]
 	path = libsignal-protocol-c
 	url = git@github.com:signalapp/libsignal-protocol-c.git
+[submodule "ios-cmake"]
+	path = ios-cmake
+	url = git@github.com:leetal/ios-cmake.git

--- a/README.md
+++ b/README.md
@@ -10,6 +10,16 @@ So far, integration of the framework into other projects is not working through 
 
 It should be possible to download the framework and add it to an existing Xcode workspace.
 
+## Building Library
+
+```sh
+$ git clone https://github.com/bitmark-inc/libsignal-protocol-swift.git
+$ cd libsignal-protocol-swift
+$ ./build.sh
+```
+
+The resulting frameworks are build/SignalModule.xcframework and build/SignalProtocol.xcframework. Add both to your project.
+
 ## Library initialization
 
 In contrast to `libsignal-protocol-c` there is no need to initialize a global

--- a/build.sh
+++ b/build.sh
@@ -8,6 +8,12 @@ SIGNAL_PROTOCOL_OUTPUT_DIR=${OUTPUT_DIR}/SignalModuleMap
 UNIVERSAL_OUTPUT_DIR=${OUTPUT_DIR}/${CONFIGURATION}-universal
 RELEASE_DIR=${PROJECT_DIR}/build
 
+clean_up()
+(
+    rm -rf "${RELEASE_DIR}/${PRODUCT_NAME}.xcframework"
+    rm -rf "${RELEASE_DIR}/SignalModule.xcframework"
+)
+
 get_dependencies()
 (
     git submodule update --init --recursive
@@ -37,9 +43,13 @@ build_c_libraries()
 
 build_signal_module()
 (
+    mkdir -p "${OUTPUT_DIR}/Headers/libsignal-protocol-c"
+    cp -R "/usr/local/include/signal/" "${OUTPUT_DIR}/Headers/libsignal-protocol-c"
+    cp -R $PROJECT_DIR/module.modulemap ${OUTPUT_DIR}/Headers/libsignal-protocol-c
+    
     xcodebuild -create-xcframework \
-        -library "${SIGNAL_PROTOCOL_OUTPUT_DIR}/OS64/libsignal-protocol-c.a" -headers "/usr/local/include/signal/" \
-        -library "${SIGNAL_PROTOCOL_OUTPUT_DIR}/SIMULATOR64/libsignal-protocol-c.a" -headers "/usr/local/include/signal/" \
+        -library "${SIGNAL_PROTOCOL_OUTPUT_DIR}/OS64/libsignal-protocol-c.a" -headers "${OUTPUT_DIR}/Headers/" \
+        -library "${SIGNAL_PROTOCOL_OUTPUT_DIR}/SIMULATOR64/libsignal-protocol-c.a" -headers "${OUTPUT_DIR}/Headers/" \
         -output "${SIGNAL_PROTOCOL_OUTPUT_DIR}/SignalModule.xcframework"
     
     cp -R "${SIGNAL_PROTOCOL_OUTPUT_DIR}/SignalModule.xcframework" "${RELEASE_DIR}"
@@ -76,6 +86,7 @@ build_swift_xcframework()
 
 (
     get_dependencies
+    clean_up
     mkdir -p "${UNIVERSAL_OUTPUT_DIR}"
     build_c_libraries
     build_signal_module

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,86 @@
+#!/bin/sh
+PROJECT_DIR=${PWD}
+OUTPUT_DIR=${PROJECT_DIR}/output
+CONFIGURATION=Release
+PROJECT_NAME="libsignal-protocol-swift iOS"
+PRODUCT_NAME=SignalProtocol
+SIGNAL_PROTOCOL_OUTPUT_DIR=${OUTPUT_DIR}/SignalModuleMap
+UNIVERSAL_OUTPUT_DIR=${OUTPUT_DIR}/${CONFIGURATION}-universal
+RELEASE_DIR=${PROJECT_DIR}/build
+
+get_dependencies()
+(
+    git submodule update --init --recursive
+)
+
+build_c_library()
+(
+    PLATFORM=$1
+
+    mkdir -p "${SIGNAL_PROTOCOL_OUTPUT_DIR}/${PLATFORM}"
+    cd "${SIGNAL_PROTOCOL_OUTPUT_DIR}/${PLATFORM}"
+    cmake "${PROJECT_DIR}/libsignal-protocol-c" -G Xcode -DCMAKE_TOOLCHAIN_FILE="${PROJECT_DIR}/ios-cmake/iOS.toolchain.cmake" -DPLATFORM=${PLATFORM}
+
+    make clean
+    mkdir -p "${OUTPUT_DIR}/OS64"
+    cmake --build .  --config Release --target install
+
+    cp -R "/usr/local/lib/libsignal-protocol-c.a" "${OUTPUT_DIR}/SignalModuleMap/${PLATFORM}/"
+    cd ${PROJECT_DIR}
+)
+
+build_c_libraries()
+(
+    build_c_library "OS64"
+    build_c_library "SIMULATOR64"
+)
+
+build_signal_module()
+(
+    xcodebuild -create-xcframework \
+        -library "${SIGNAL_PROTOCOL_OUTPUT_DIR}/OS64/libsignal-protocol-c.a" -headers "/usr/local/include/signal/" \
+        -library "${SIGNAL_PROTOCOL_OUTPUT_DIR}/SIMULATOR64/libsignal-protocol-c.a" -headers "/usr/local/include/signal/" \
+        -output "${SIGNAL_PROTOCOL_OUTPUT_DIR}/SignalModule.xcframework"
+    
+    cp -R "${SIGNAL_PROTOCOL_OUTPUT_DIR}/SignalModule.xcframework" "${RELEASE_DIR}"
+)
+
+build_swift_framework()
+(
+    PLATFORM=$1
+    
+    xcodebuild -target "${PROJECT_NAME}" ONLY_ACTIVE_ARCH=NO -configuration ${CONFIGURATION} CONFIGURATION_BUILD_DIR="${OUTPUT_DIR}/${PLATFORM}" build -sdk ${PLATFORM}
+)
+
+build_swift_frameworks()
+(
+    build_swift_framework "iphoneos"
+    build_swift_framework "iphonesimulator"
+)
+
+build_swift_xcframework()
+(
+    xcodebuild -create-xcframework \
+        -output "${UNIVERSAL_OUTPUT_DIR}/${PRODUCT_NAME}.xcframework" \
+        -framework "${OUTPUT_DIR}/iphonesimulator/${PRODUCT_NAME}.framework" \
+        -framework "${OUTPUT_DIR}/iphoneos/${PRODUCT_NAME}.framework"
+        
+    rm -rf "${UNIVERSAL_OUTPUT_DIR}/${PRODUCT_NAME}.xcframework/ios-arm64_x86_64-simulator/${PRODUCT_NAME}.framework"
+    cp -R ${OUTPUT_DIR}/iphonesimulator/${PRODUCT_NAME}.framework ${UNIVERSAL_OUTPUT_DIR}/${PRODUCT_NAME}.xcframework/ios-arm64_x86_64-simulator/
+
+    rm -rf "${UNIVERSAL_OUTPUT_DIR}/${PRODUCT_NAME}.xcframework/ios-arm64/${PRODUCT_NAME}.framework"
+    cp -R ${OUTPUT_DIR}/iphoneos/${PRODUCT_NAME}.framework ${UNIVERSAL_OUTPUT_DIR}/${PRODUCT_NAME}.xcframework/ios-arm64/
+    
+    cp -R "${UNIVERSAL_OUTPUT_DIR}/${PRODUCT_NAME}.xcframework" "${RELEASE_DIR}"
+)
+
+(
+    get_dependencies
+    mkdir -p "${UNIVERSAL_OUTPUT_DIR}"
+    build_c_libraries
+    build_signal_module
+    build_swift_frameworks
+    build_swift_xcframework
+    rm -rf ${OUTPUT_DIR}
+    open ${RELEASE_DIR}
+)

--- a/libsignal-protocol-swift/Setup/Signal.swift
+++ b/libsignal-protocol-swift/Setup/Signal.swift
@@ -36,6 +36,25 @@ public final class Signal {
 }
 
 public extension Signal {
+    
+    static func publicKey(for privateKey: Data) throws -> Data {
+        
+        var pubKey: OpaquePointer? = nil
+        let result = withUnsafeMutablePointer(to: &pubKey) {
+            curve_generate_public_key($0, privateKey.signalBuffer)
+        }
+
+        guard result == 0 else { throw SignalError(value: result) }
+        
+        var pubBuffer: OpaquePointer? = nil
+        let result2 = withUnsafeMutablePointer(to: &pubBuffer) {
+            ec_public_key_serialize($0, pubKey)
+        }
+        
+        guard result2 == 0 else { throw SignalError(value: result) }
+        
+        return Data(signalBuffer: pubBuffer!)
+    }
 
     /**
      Generate an identity key pair.  Clients should only do this once,

--- a/libsignal-protocol-swift/Setup/Signal.swift
+++ b/libsignal-protocol-swift/Setup/Signal.swift
@@ -38,11 +38,12 @@ public final class Signal {
 public extension Signal {
     
     static func publicKey(for privateKey: Data) throws -> Data {
-        
+        let privateBuffer = privateKey.signalBuffer
         var pubKey: OpaquePointer? = nil
         let result = withUnsafeMutablePointer(to: &pubKey) {
             curve_generate_public_key($0, privateKey.signalBuffer)
         }
+        defer { signal_buffer_free(privateBuffer) }
 
         guard result == 0 else { throw SignalError(value: result) }
         
@@ -53,7 +54,9 @@ public extension Signal {
         
         guard result2 == 0 else { throw SignalError(value: result) }
         
-        return Data(signalBuffer: pubBuffer!)
+        let pubkey = Data(signalBuffer: pubBuffer!)
+        signal_buffer_free(pubBuffer)
+        return pubkey
     }
 
     /**

--- a/module.modulemap
+++ b/module.modulemap
@@ -1,0 +1,11 @@
+module SignalModule {
+    header "signal_protocol.h"
+    header "key_helper.h"
+    header "session_builder.h"
+    header "session_cipher.h"
+    header "protocol.h"
+    header "group_session_builder.h"
+    header "group_cipher.h"
+    header "fingerprint.h"
+    export *
+}


### PR DESCRIPTION
- Add build script to generate xcframework.
- Update library to be able to import a keypair for signal identity.